### PR TITLE
Replace cover and footer logos with Spring4 assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <div class="content flex flex-col justify-center items-center h-full py-8 px-10">
         <div class="text-center mb-8">
           <div class="logo-container flex justify-center logo-raised">
-            <img class="logo" src="assets/Logo_main-min.png" alt="Epohers Logo" style="max-width: 400px; filter: drop-shadow(6px 6px 16px rgba(0, 0, 0, 0.9));">
+            <img class="logo" src="spring_assets/Logo_Spring4.png" alt="Epohers Logo" style="max-width: 400px; filter: drop-shadow(6px 6px 16px rgba(0, 0, 0, 0.9));">
           </div>
           <h1 class="section-title text-7xl mb-10">EPOHERS WORLD CUP</h1>
           <h2 class="text-5xl font-semibold">Age of Empires IV Tournament</h2>
@@ -92,7 +92,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10">
         <div class="mb-12 text-center">
@@ -131,7 +131,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-8 px-10">
         <div class="mb-8 text-center">
@@ -205,7 +205,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10" style="margin-top: 2rem;">
         <div class="mb-4 text-center">
@@ -239,7 +239,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10">
         <div class="mb-4 text-center">
@@ -278,7 +278,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+          <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10">
         <div class="mb-8 text-center">
@@ -335,7 +335,7 @@
         <div class="edge-vignette"></div>
         <div class="pagination"></div>
         <div class="absolute bottom-10 right-10">
-            <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+          <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
         </div>
         <div class="content flex flex-col h-full py-8 px-10">
             <div class="mb-8 text-center">
@@ -432,7 +432,7 @@
         <div class="edge-vignette"></div>
         <div class="pagination"></div>
         <div class="absolute bottom-10 right-10">
-            <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+          <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
         </div>
         <div class="content flex flex-col h-full pt-2 px-10">
             <div class="mb-4 text-center">
@@ -577,7 +577,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10">
         <div class="mb-8 text-center">
@@ -610,7 +610,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-8 px-10">
         <div class="mb-8 text-center">
@@ -663,7 +663,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-16 px-10">
         <div class="mb-8 text-center">
@@ -707,7 +707,7 @@
       <div class="edge-vignette"></div>
       <div class="pagination"></div>
       <div class="absolute bottom-10 right-10">
-        <img src="assets/Logo_main-min.png" alt="Epohers Logo" class="w-24">
+        <img src="spring_assets/Logo_Spring4_small.png" alt="Epohers Logo" class="w-24">
       </div>
       <div class="content flex flex-col h-full py-8 px-10">
         <div class="mb-8 text-center">


### PR DESCRIPTION
### Motivation
- Swap the cover and slide footer logos to the Spring4 assets so branding matches the new Spring theme.
- Ensure the replacements preserve current sizing and visual treatment so the logo remains visible against slide backgrounds.
- No skills were used for this change.

### Description
- Update the cover logo image at `.logo-container img.logo` to use `spring_assets/Logo_Spring4.png` while preserving the `max-width` and `filter: drop-shadow` inline style in `index.html`.
- Replace all bottom-right slide logos at `.absolute.bottom-10.right-10 img` to `spring_assets/Logo_Spring4_small.png`, keeping the existing `w-24` sizing class in `index.html`.
- No CSS changes were made; the change is limited to swapping the `src` attributes in `index.html`.

### Testing
- Verified occurrences by inspecting `index.html` and confirming all targeted `bottom-10 right-10` image tags reference the new small Spring4 asset (search/inspection succeeded).
- Served the site with `python -m http.server` and captured a visual screenshot of the cover slide using a Playwright script, which completed successfully and produced the artifact `artifacts/spring-logo-cover.png` (visual smoke test passed).
- No unit-test suite was applicable for this static HTML update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f85564f0832498bed128d002c239)