### PR TITLE
Refine spring overlays, leaf layouts, and gradient underlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,13 +726,13 @@
           </div>
             <div class="collage-container">
                 <img src="assets/Logo_main-min.png" class="collage-image">
-                <img src="assets/leves_1-min.png" class="collage-image">
-                <img src="assets/leves_2-min.png" class="collage-image">
-                <img src="assets/leves_3-min.png" class="collage-image">
-                <img src="assets/leves_4-min.png" class="collage-image">
-                <img src="assets/leves_5-min.png" class="collage-image">
-                <img src="assets/leves_6-min.png" class="collage-image">
-                <img src="assets/leves_7-min.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_green_mid1.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_pink_mid2.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_green_small3.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_pink_mid5.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_green_mid6.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_green_small5.png" class="collage-image">
+                <img src="spring_assets/leaves/leaves_pink_mid8.png" class="collage-image">
                 <img src="assets/icon_swords-min.png" class="collage-image">
                 <img src="assets/icon_troph2-min.png" class="collage-image">
                 <img src="assets/icon_troph-min.png" class="collage-image">

--- a/script.js
+++ b/script.js
@@ -166,18 +166,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const leafLayoutsBySlide = [
     [
-      { src: 'spring_assets/leaves/leaves_green_mid3.png', top: '12%', left: '18%', rotate: -25, scale: 1.1, width: 160, height: 160 },
-      { src: 'spring_assets/leaves/leaves_pink_mid4.png', top: '18%', left: '30%', rotate: -12, scale: 1.05, width: 150, height: 150 },
-      { src: 'spring_assets/leaves/leaves_green_small2.png', top: '24%', left: '44%', rotate: 4, scale: 0.8, width: 90, height: 90 },
-      { src: 'spring_assets/leaves/leaves_green_mid5.png', top: '70%', left: '8%', rotate: 18, scale: 1.05, width: 150, height: 150 },
-      { src: 'spring_assets/leaves/leaves_pink_mid2.png', top: '64%', left: '22%', rotate: 32, scale: 1.1, width: 155, height: 155 },
-      { src: 'spring_assets/leaves/leaves_green_small4.png', top: '58%', left: '36%', rotate: 44, scale: 0.85, width: 95, height: 95 },
-      { src: 'spring_assets/leaves/leaves_pink_mid7.png', top: '30%', left: '58%', rotate: 12, scale: 1.05, width: 145, height: 145 },
-      { src: 'spring_assets/leaves/leaves_green_mid1.png', top: '22%', left: '70%', rotate: 0, scale: 1, width: 145, height: 145 },
-      { src: 'spring_assets/leaves/leaves_green_small6.png', top: '16%', left: '82%', rotate: -10, scale: 0.8, width: 90, height: 90 },
-      { src: 'spring_assets/leaves/leaves_pink_mid5.png', top: '76%', left: '48%', rotate: 52, scale: 1.1, width: 155, height: 155 },
-      { src: 'spring_assets/leaves/leaves_green_mid8.png', top: '84%', left: '64%', rotate: 38, scale: 1.05, width: 150, height: 150 },
-      { src: 'spring_assets/leaves/leaves_green_small1.png', top: '68%', left: '78%', rotate: 28, scale: 0.85, width: 95, height: 95 }
+      { src: 'spring_assets/leaves/leaves_green_mid7.png', top: '6%', left: '8%', rotate: -35, scale: 1.15, width: 180, height: 180 },
+      { src: 'spring_assets/leaves/leaves_pink_mid9.png', top: '10%', left: '22%', rotate: -18, scale: 1.1, width: 170, height: 170 },
+      { src: 'spring_assets/leaves/leaves_green_small4.png', top: '14%', left: '36%', rotate: -6, scale: 0.85, width: 95, height: 95 },
+      { src: 'spring_assets/leaves/leaves_green_mid2.png', top: '18%', left: '52%', rotate: 8, scale: 1.1, width: 165, height: 165 },
+      { src: 'spring_assets/leaves/leaves_pink_mid4.png', top: '12%', left: '70%', rotate: 14, scale: 1.05, width: 160, height: 160 },
+      { src: 'spring_assets/leaves/leaves_green_small1.png', top: '10%', left: '84%', rotate: -8, scale: 0.8, width: 90, height: 90 },
+      { src: 'spring_assets/leaves/leaves_pink_mid6.png', top: '28%', left: '10%', rotate: 26, scale: 1.1, width: 165, height: 165 },
+      { src: 'spring_assets/leaves/leaves_green_mid5.png', top: '32%', left: '26%', rotate: 18, scale: 1.05, width: 155, height: 155 },
+      { src: 'spring_assets/leaves/leaves_green_small6.png', top: '38%', left: '42%', rotate: 30, scale: 0.85, width: 95, height: 95 },
+      { src: 'spring_assets/leaves/leaves_pink_mid2.png', top: '44%', left: '58%', rotate: 22, scale: 1.1, width: 165, height: 165 },
+      { src: 'spring_assets/leaves/leaves_green_mid8.png', top: '36%', left: '74%', rotate: 10, scale: 1.05, width: 155, height: 155 },
+      { src: 'spring_assets/leaves/leaves_green_small2.png', top: '30%', left: '88%', rotate: -2, scale: 0.8, width: 90, height: 90 },
+      { src: 'spring_assets/leaves/leaves_pink_mid5.png', top: '70%', left: '6%', rotate: 38, scale: 1.1, width: 170, height: 170 },
+      { src: 'spring_assets/leaves/leaves_green_mid1.png', top: '74%', left: '22%', rotate: 30, scale: 1.05, width: 160, height: 160 },
+      { src: 'spring_assets/leaves/leaves_green_small3.png', top: '66%', left: '38%', rotate: 40, scale: 0.85, width: 95, height: 95 },
+      { src: 'spring_assets/leaves/leaves_pink_mid7.png', top: '78%', left: '54%', rotate: 46, scale: 1.1, width: 170, height: 170 },
+      { src: 'spring_assets/leaves/leaves_green_mid3.png', top: '82%', left: '70%', rotate: 34, scale: 1.05, width: 160, height: 160 },
+      { src: 'spring_assets/leaves/leaves_green_small5.png', top: '72%', left: '86%', rotate: 24, scale: 0.85, width: 95, height: 95 }
     ],
     [
       { src: 'spring_assets/leaves/leaves_green_mid1.png', top: '10%', left: '62%', rotate: -18, scale: 1.05, width: 150, height: 150 },

--- a/style.css
+++ b/style.css
@@ -41,6 +41,9 @@
       display: block;
       opacity: 1;
     }
+    .slide:first-child .background {
+      background-position: center center;
+    }
     .background {
       position: absolute;
       top: 0;
@@ -59,8 +62,8 @@
       left: 0;
       width: 100%;
       height: 100%;
-      background-color: rgba(5, 18, 24, 0.55);
-      z-index: 2;
+      background-color: rgba(5, 18, 24, 0.275);
+      z-index: 3;
     }
     .edge-vignette {
       position: absolute;
@@ -69,13 +72,13 @@
       width: 100%;
       height: 100%;
       box-shadow: inset 0 0 170px 70px rgba(4, 18, 24, 0.75);
-      z-index: 2;
+      z-index: 3;
       pointer-events: none;
     }
     .leaves-decoration {
       position: absolute;
       opacity: 1;
-      z-index: 3;
+      z-index: 2;
       pointer-events: none;
       background-size: contain;
       background-repeat: no-repeat;
@@ -116,9 +119,21 @@
       color: var(--primary-color);
       letter-spacing: 1px;
       text-transform: uppercase;
-      border-bottom: 3px solid var(--accent-color);
       display: inline-block;
       font-size: 5rem;
+      position: relative;
+      padding-bottom: 12px;
+    }
+    .section-title::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 4px;
+      background: linear-gradient(90deg, rgba(110, 201, 255, 0.9) 0%, rgba(77, 208, 225, 0.9) 50%, rgba(126, 232, 161, 0.9) 100%);
+      border-radius: 999px;
+      box-shadow: 0 0 8px rgba(110, 201, 255, 0.35);
     }
     .text-7xl {
       font-size: 6rem;
@@ -328,9 +343,10 @@
     }
     .toc-line {
       flex-grow: 1;
-      height: 1px;
-      background-color: rgba(255, 210, 125, 0.4);
+      height: 2px;
+      background: linear-gradient(90deg, rgba(110, 201, 255, 0.65) 0%, rgba(77, 208, 225, 0.65) 50%, rgba(126, 232, 161, 0.65) 100%);
       margin: 0 10px;
+      border-radius: 999px;
     }
     .toc-page-number {
       font-family: 'Cinzel', serif;
@@ -834,10 +850,13 @@
     }
     .toc-list-dots {
       flex-grow: 1;
-      border-bottom: 2px dotted rgba(255, 210, 125, 0.5);
+      border-bottom: none;
+      height: 2px;
+      background: linear-gradient(90deg, rgba(110, 201, 255, 0.7) 0%, rgba(77, 208, 225, 0.7) 50%, rgba(126, 232, 161, 0.7) 100%);
       margin: 0 0.5rem;
       transform: translateY(-4px);
       transition: border-color 0.2s;
+      border-radius: 999px;
     }
     .toc-list-page {
       color: var(--primary-color);


### PR DESCRIPTION
### Motivation
- Improve visual layering so decorative leaves sit under the fog overlay and content stays above, and make the fog lighter and semi-transparent.
- Create a more "epic" leaf composition on the first slide and replace stale leaf assets in the `11.1 Content creating` collage with the new spring leaves.
- Make heading underlines and table-of-contents lines match card gradients by using gradient treatments instead of flat/dotted lines.

### Description
- Updated `style.css` to reduce overlay opacity, raise `overlay` and `edge-vignette` z-index, lower leaf decorations under the overlay by setting `.leaves-decoration { z-index: 2 }`, and keep `.content` above with `z-index: 4`.
- Replaced the flat section underline with a gradient pseudo-element for `.section-title::after` and converted `.toc-line` and `.toc-list-dots` to rounded gradient lines for a cohesive look.
- Centered the first slide background via `.slide:first-child .background { background-position: center center }` and adjusted line heights/sizes for the new visuals.
- Reworked the first slide leaf layout in `script.js` to a denser, larger composition (new positions, rotations, scales and assets) to achieve a more epic visual.
- Replaced the old leaf images in the `11.1 Content creating` collage inside `index.html` with new spring assets under `spring_assets/leaves/`.

### Testing
- Launched a local static server with `python -m http.server 8000` and rendered the page with a Playwright script which produced a screenshot at `artifacts/spring-slide-1.png`, and the render completed successfully.
- No unit tests were added or run because changes are visual CSS/asset updates and were validated via the generated screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ec6285d88324ae3b70fffd29d9f4)