### PR TITLE
Round slide border corners for rollbook frame

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,9 +33,11 @@
       opacity: 0;
       transition: opacity 0.5s ease-in-out;
       border: 2px solid rgba(255, 210, 125, 0.5);
-      border-radius: 15px;
+      border-radius: 16px;
       box-sizing: border-box;
       padding: 20px;
+      overflow: hidden;
+      background-color: var(--dark-bg);
     }
     .slide.active {
       display: block;
@@ -55,6 +57,7 @@
       background-size: cover;
       background-position: center;
       opacity: 0.85;
+      border-radius: inherit;
     }
     .overlay {
       position: absolute;
@@ -64,6 +67,7 @@
       height: 100%;
       background-color: rgba(5, 18, 24, 0.275);
       z-index: 3;
+      border-radius: inherit;
     }
     .edge-vignette {
       position: absolute;
@@ -74,6 +78,7 @@
       box-shadow: inset 0 0 170px 70px rgba(4, 18, 24, 0.75);
       z-index: 3;
       pointer-events: none;
+      border-radius: inherit;
     }
     .leaves-decoration {
       position: absolute;


### PR DESCRIPTION
### Motivation
- Make the thin beige outline on slide frames render as rounded at the corners while exposing the dark background behind it so the frame corners look clean and consistent.

### Description
- Update `style.css` to change the `.slide` `border-radius` from `15px` to `16px`, add `overflow: hidden` and `background-color: var(--dark-bg)`, and make `.background`, `.overlay`, and `.edge-vignette` use `border-radius: inherit` so overlays are clipped to the rounded frame.

### Testing
- Launched a local static server and ran a Playwright script to load `index.html` and capture a screenshot (`artifacts/rollbook-border.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698512f5beac8324a328f23e1e8fef5f)